### PR TITLE
chore: package maintenance

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "release": "pnpm run lint && pnpm run prepack && release-it"
   },
   "dependencies": {
-    "@antelopejs/interface-core": "^0.0.2",
+    "@antelopejs/interface-core": "^0.0.3",
     "stripe": "^18.5.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -24,18 +24,7 @@
       "types": "./dist/index.d.ts",
       "default": "./dist/index.js"
     },
-    "./*": {
-      "types": "./dist/*.d.ts",
-      "default": "./dist/*.js"
-    },
     "./package.json": "./package.json"
-  },
-  "typesVersions": {
-    "*": {
-      "*": [
-        "dist/*.d.ts"
-      ]
-    }
   },
   "scripts": {
     "build": "rimraf dist && tsc",
@@ -59,5 +48,6 @@
   },
   "publishConfig": {
     "access": "public"
-  }
+  },
+  "antelopeJs": {}
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,8 +9,8 @@ importers:
   .:
     dependencies:
       '@antelopejs/interface-core':
-        specifier: ^0.0.2
-        version: 0.0.2
+        specifier: ^0.0.3
+        version: 0.0.3
       stripe:
         specifier: ^18.5.0
         version: 18.5.0(@types/node@22.19.15)
@@ -36,8 +36,8 @@ importers:
 
 packages:
 
-  '@antelopejs/interface-core@0.0.2':
-    resolution: {integrity: sha512-CmtOJvSCRj20GOQhrE0PpHybGaW1G1lrepiKHVJa/bclhrvFYgHV0MH84TMpMOHESQT/+wuup007tfXAwaI+Eg==}
+  '@antelopejs/interface-core@0.0.3':
+    resolution: {integrity: sha512-Kw3ffGiQHKJ88AqdFfPuwzl+v0w6QqzqiqnLY7M0MYYw+YwdRNXh5WAJkep0ePudR9leLGXPU//FYizNaDG6yw==}
 
   '@biomejs/biome@2.3.2':
     resolution: {integrity: sha512-8e9tzamuDycx7fdrcJ/F/GDZ8SYukc5ud6tDicjjFqURKYFSWMl0H0iXNXZEGmcmNUmABgGuHThPykcM41INgg==}
@@ -477,6 +477,9 @@ packages:
 
   defu@6.1.4:
     resolution: {integrity: sha512-mEQCMmwJu317oSz8CwdIOdwf3xMif1ttiM8LTufzc3g6kR+9Pe236twL8j3IYT1F7GfRgGcW6MWxzZjLIkuHIg==}
+
+  defu@6.1.7:
+    resolution: {integrity: sha512-7z22QmUWiQ/2d0KkdYmANbRUVABpZ9SNYyH5vx6PZ+nE5bcC0l7uFvEfHlyld/HcGBFTL536ClDt3DEcSlEJAQ==}
 
   degenerator@5.0.1:
     resolution: {integrity: sha512-TllpMR/t0M5sqCXfj85i4XaAzxmS5tVA16dqvdkMwGmzI+dXLXnw3J+3Vdv7VKw+ThlTMboK6i9rnZ6Nntj5CQ==}
@@ -1188,7 +1191,7 @@ packages:
 
 snapshots:
 
-  '@antelopejs/interface-core@0.0.2':
+  '@antelopejs/interface-core@0.0.3':
     dependencies:
       reflect-metadata: 0.2.2
 
@@ -1480,7 +1483,7 @@ snapshots:
     dependencies:
       chokidar: 3.6.0
       confbox: 0.1.8
-      defu: 6.1.4
+      defu: 6.1.7
       dotenv: 16.6.1
       giget: 1.2.5
       jiti: 1.21.7
@@ -1612,6 +1615,8 @@ snapshots:
 
   defu@6.1.4: {}
 
+  defu@6.1.7: {}
+
   degenerator@5.0.1:
     dependencies:
       ast-types: 0.13.4
@@ -1723,7 +1728,7 @@ snapshots:
     dependencies:
       citty: 0.1.6
       consola: 3.4.2
-      defu: 6.1.4
+      defu: 6.1.7
       node-fetch-native: 1.6.7
       nypm: 0.5.4
       pathe: 2.0.3


### PR DESCRIPTION
## Summary
- Add `antelopeJs` field to package.json (empty object for consistency across interface-* repos)
- Remove wildcard subpath exports (`./*` and `typesVersions` wildcard) to hide internal dist paths from consumers
- Bump `@antelopejs/interface-core` dependency to `^0.0.3`

## Test plan
- [ ] Verify build still passes: `pnpm run build`
- [ ] Verify lint still passes: `pnpm run lint`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR performs routine package maintenance: it removes wildcard subpath exports (`./*` and the matching `typesVersions` entry) to prevent consumers from importing internal dist paths, bumps `@antelopejs/interface-core` to `^0.0.3`, and adds an empty `antelopeJs` field for consistency with other interface-* packages. The lockfile update is consistent with the dependency change and introduces no unexpected transitive dependency shifts.

<h3>Confidence Score: 5/5</h3>

Safe to merge — all changes are intentional and low-risk package maintenance with no logic or security concerns.

All findings are P2 or lower. The removal of wildcard exports is a deliberate, documented breaking-change guard; the dependency bump is minor; and the lockfile is consistent. No correctness, security, or reliability issues were identified.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| package.json | Removes wildcard subpath exports and typesVersions wildcard, bumps @antelopejs/interface-core to ^0.0.3, and adds antelopeJs empty object field for consistency. |
| pnpm-lock.yaml | Lockfile updated to reflect @antelopejs/interface-core 0.0.3 and defu 6.1.7 transitive dependency upgrade; no anomalies. |

</details>

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Consumer imports package] --> B{Subpath requested?}
    B -- "." --> C["./dist/index.js (kept)"]
    B -- "./package.json" --> D["./package.json (kept)"]
    B -- "./*  (any other)" --> E_old["❌ Removed: ./dist/*.js"]
    E_old -.->|"Before PR"| F[Internal dist exposed]
    C --> G[✅ Public API only]
    D --> G
    style E_old stroke-dasharray: 5 5,color:#999
    style F stroke-dasharray: 5 5,color:#999
    style G fill:#22c55e,color:#fff
```

<sub>Reviews (1): Last reviewed commit: ["chore: bump @antelopejs/interface-core t..."](https://github.com/antelopejs/interface-stripe/commit/bccff076de74f859df33a17ce4b968289bcb1e9f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29167073)</sub>

<!-- /greptile_comment -->