### PR TITLE
chore(deps): interface-core as bounded peer + dev dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,16 +35,19 @@
     "release": "pnpm run lint && pnpm run prepack && release-it"
   },
   "dependencies": {
-    "@antelopejs/interface-core": "^0.0.3",
     "stripe": "^18.5.0"
   },
   "devDependencies": {
+    "@antelopejs/interface-core": ">=0.0.3 <1.0.0",
     "@biomejs/biome": "2.3.2",
     "@types/node": "^22.19.15",
     "release-it": "^19.2.4",
     "release-it-changelogen": "^0.1.0",
     "rimraf": "^6.1.3",
     "typescript": "^5.9.3"
+  },
+  "peerDependencies": {
+    "@antelopejs/interface-core": ">=0.0.3 <1.0.0"
   },
   "publishConfig": {
     "access": "public"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,13 +8,13 @@ importers:
 
   .:
     dependencies:
-      '@antelopejs/interface-core':
-        specifier: ^0.0.3
-        version: 0.0.3
       stripe:
         specifier: ^18.5.0
         version: 18.5.0(@types/node@22.19.15)
     devDependencies:
+      '@antelopejs/interface-core':
+        specifier: '>=0.0.3 <1.0.0'
+        version: 0.0.3
       '@biomejs/biome':
         specifier: 2.3.2
         version: 2.3.2


### PR DESCRIPTION
Move `@antelopejs/interface-core` from dependencies to peerDependencies (bounded to the current major, e.g. `>=0.0.5 <0.1.0`) and mirror it in devDependencies for standalone compilation. interface-core is a host-provided runtime singleton; this avoids dual installs and version-pinning overrides downstream. Verified: install, build, lint.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR moves `@antelopejs/interface-core` from a runtime `dependency` to a `peerDependency` (with a mirrored `devDependency`), which is the correct pattern for a host-provided singleton to avoid duplicate installs and version-pinning conflicts in consuming projects.

- The peer dependency version range `>=0.0.3 <1.0.0` is broader than the PR description's stated intent ("bounded to the current major, e.g. `>=0.0.5 <0.1.0`"). For a pre-1.0 package, minor-version bumps (`0.1.0`, `0.2.0`, …) can carry breaking changes, so the safe bound is `<0.1.0`, not `<1.0.0`.
- The `devDependencies` entry carries the same wide range and should be tightened to match, so local builds exercise the same constraint consumers will see.

<h3>Confidence Score: 4/5</h3>

The structural intent is correct — moving interface-core to a peer dep is the right pattern — but the version range is wider than intended and could allow incompatible pre-1.0 minor releases to satisfy the constraint downstream.

The peer and dev dependency range >=0.0.3 <1.0.0 permits any 0.x.x version of a pre-1.0 package where minor bumps are not guaranteed to be non-breaking. The PR description explicitly states the goal as bounding to the current minor series, making the wider range an unintentional overshoot that could cause compatibility issues for downstream consumers.

package.json — the peerDependencies and devDependencies version range for @antelopejs/interface-core needs to be tightened from <1.0.0 to <0.1.0

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| package.json | Moves @antelopejs/interface-core from dependencies to peerDependencies + devDependencies; version range widened to >=0.0.3 <1.0.0, which is broader than the PR description's stated intent of bounding to the current minor (0.0.x) |
| pnpm-lock.yaml | Lockfile updated to reflect the move of @antelopejs/interface-core from dependencies to devDependencies; resolved version remains 0.0.3 |

</details>

</details>

<h3>Flowchart</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["Consumer project\n(installs interface-stripe)"] -->|"peerDependencies\n>=0.0.3 <1.0.0"| B["@antelopejs/interface-core\n(host-provided)"]
    A -->|"dependencies"| C["@antelopejs/interface-stripe"]
    C -->|"runtime dependency"| D["stripe ^18.5.0"]
    C -->|"devDependencies (build only)"| B
    style B fill:#f9c,stroke:#c66
    style C fill:#cdf,stroke:#66c
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A["Consumer project\n(installs interface-stripe)"] -->|"peerDependencies\n>=0.0.3 <1.0.0"| B["@antelopejs/interface-core\n(host-provided)"]
    A -->|"dependencies"| C["@antelopejs/interface-stripe"]
    C -->|"runtime dependency"| D["stripe ^18.5.0"]
    C -->|"devDependencies (build only)"| B
    style B fill:#f9c,stroke:#c66
    style C fill:#cdf,stroke:#66c
```

</a>

<sub>Reviews (2): Last reviewed commit: ["chore(deps): interface deps as bounded p..."](https://github.com/antelopejs/interface-stripe/commit/e0b86ad79e705dd1cdb8ab83fefe1b2c287a5768) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37739221)</sub>

<!-- /greptile_comment -->