### PR TITLE
feat(skills): ship a consumer skill with the package

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,9 @@
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "files": [
-    "dist"
+    "dist",
+    "docs",
+    "skills"
   ],
   "exports": {
     ".": {
@@ -52,5 +54,7 @@
   "publishConfig": {
     "access": "public"
   },
-  "antelopeJs": {}
+  "antelopeJs": {
+    "skills": ["./skills"]
+  }
 }

--- a/package.json
+++ b/package.json
@@ -55,6 +55,8 @@
     "access": "public"
   },
   "antelopeJs": {
-    "skills": ["./skills"]
+    "skills": [
+      "./skills"
+    ]
   }
 }

--- a/skills/stripe-interface/SKILL.md
+++ b/skills/stripe-interface/SKILL.md
@@ -47,9 +47,15 @@ WatchPayment(intent.id, (payloadId, intent, context) => {
   // payloadId === intent.metadata.payload (the id given to InitializePayment)
 });
 
+// Filter at registration: only local events reach the callback
+WatchAllPayments((payloadId, intent, context) => {
+  // context.local is always true here
+}, /* onlyLocal */ true);
+
+// …or filter manually inside the callback
 WatchAllPayments((payloadId, intent, context) => {
   if (!context.local) return; // event came from another cluster instance
-}, /* onlyLocal */ true); // or filter at registration
+});
 ```
 
 Escape hatch for anything the helpers don't cover:

--- a/skills/stripe-interface/SKILL.md
+++ b/skills/stripe-interface/SKILL.md
@@ -1,0 +1,73 @@
+---
+name: stripe-interface
+description: Provides Stripe payment processing for AntelopeJS modules - payment-intent creation, completion, awaiting terminal states, cluster-aware payment event watching, and access to the raw Stripe SDK client. Use when code imports "@antelopejs/interface-stripe" or uses GetClient, InitializePayment, WaitForPayment, CompletePayment, WatchAllPayments, WatchPayment, or IntentChangeContext, or when a task involves Stripe payments, payment intents, charges, or payment webhooks in an AntelopeJS project.
+category: antelopejs-interface
+tags: [stripe, payments, payment-intent, webhooks, antelopejs]
+---
+
+# Stripe interface
+
+Consumer-facing contract for Stripe payments in AntelopeJS. A separate provider module owns the Stripe SDK client and feeds payment-intent change events (webhooks, cluster broadcasts) into the interface; the actual proxy crossings are the shared client promise and an `EventProxy` of intent changes, both living in the `internal` namespace. Everything a consumer touches — the exported functions below — are consumer-side helpers built on that shared client and event stream. All Stripe types are the official `stripe` SDK types.
+
+## Imports
+
+Single root export, no subpaths:
+
+```ts
+import {
+  GetClient,
+  InitializePayment,
+  WaitForPayment,
+  CompletePayment,
+  WatchAllPayments,
+  WatchPayment,
+  type IntentChangeContext,
+} from "@antelopejs/interface-stripe";
+import type Stripe from "stripe"; // for PaymentIntent, Source, etc.
+```
+
+## Consuming
+
+```ts
+// Create a payment intent linked to your own id (stored in metadata.payload)
+const intent = await InitializePayment("order_123", {
+  amount: 2500, // smallest currency unit
+  currency: "usd",
+  payment_method_types: ["card"],
+});
+
+// Resolves when status reaches "succeeded"; rejects with cancellation_reason on "canceled"
+const completed = await WaitForPayment(intent.id);
+```
+
+Reacting to status changes instead of awaiting:
+
+```ts
+WatchPayment(intent.id, (payloadId, intent, context) => {
+  // payloadId === intent.metadata.payload (the id given to InitializePayment)
+});
+
+WatchAllPayments((payloadId, intent, context) => {
+  if (!context.local) return; // event came from another cluster instance
+}, /* onlyLocal */ true); // or filter at registration
+```
+
+Escape hatch for anything the helpers don't cover:
+
+```ts
+const stripe = await GetClient(); // raw Stripe SDK client
+```
+
+## Gotchas
+
+- Every client-backed helper (`GetClient`, `InitializePayment`, `WaitForPayment`, `CompletePayment`) awaits the shared client, which only resolves once a provider module implementing this interface is loaded; `WatchPayment`/`WatchAllPayments` register synchronously but receive no events until then. Declare `@antelopejs/interface-stripe` in the consuming module's `dependencies` and resolve a provider with `ajs project modules install`. Consumers never touch the `internal` namespace (`SetClient`, `intentChanges`) — that is the provider seam.
+- `WaitForPayment` retrieves the intent first: it returns immediately if already `succeeded` and rejects immediately if already `canceled`. On cancellation it rejects with the intent's `cancellation_reason`, not an `Error`.
+- The first watcher argument is `intent.metadata.payload` — it is `undefined` for intents created outside `InitializePayment`.
+- Per-intent watchers (`WatchPayment` callbacks, pending `WaitForPayment` promises) are cleaned up automatically when the intent reaches a terminal state (`succeeded` or `canceled`). `WatchAllPayments` watchers persist.
+- `onlyLocal` filtering exists only on `WatchAllPayments`; `WatchPayment` callbacks fire for both local and cluster events — check `context.local` yourself if you need to deduplicate across instances.
+- `CompletePayment` throws unless the source's `status` is `"chargeable"`; it charges the intent's own amount/currency and uses `metadata.payload` (falling back to the payment-intent id) as the idempotency key.
+- Providing this interface is not a normal consumer task: a Stripe connector module implements it by wiring the SDK client and webhook events through `internal`.
+
+## Reference
+
+Deeper reference lives in this package's `docs/` — "Payment Processing" (GetClient, InitializePayment, WaitForPayment, CompletePayment) and "Event Monitoring" (IntentChangeContext, IntentWatcher, WatchAllPayments, WatchPayment) — and in the shipped `dist/index.d.ts`. Do not duplicate them here.

--- a/skills/stripe-interface/SKILL.md
+++ b/skills/stripe-interface/SKILL.md
@@ -30,9 +30,9 @@ import type Stripe from "stripe"; // for PaymentIntent, Source, etc.
 
 ```ts
 // Create a payment intent linked to your own id (stored in metadata.payload)
-const intent = await InitializePayment("order_123", {
-  amount: 2500, // smallest currency unit
-  currency: "usd",
+const intent = await InitializePayment("library-fine-8842", {
+  amount: 450, // smallest currency unit
+  currency: "eur",
   payment_method_types: ["card"],
 });
 


### PR DESCRIPTION
## Summary
- Adds `skills/<name>-interface/SKILL.md`: a lean, source-grounded consumer guide (imports per subpath, minimal example, gotchas, pointer to the shipped `.d.ts`)
- Wires it for distribution: `antelopeJs.skills: ["./skills"]` + `skills` in the `files` array
- Consumers get it automatically: the antelopejs Claude Code plugin syncs package-shipped skills into `.claude/skills/`; the cms-ai chatbox loads them at runtime
- Content fact-checked against `src/`/`docs/` by an adversarial review pass (imports validated against the exports map, examples verified against real signatures)

## Test plan
N/A (documentation artifact; frontmatter and import paths validated mechanically)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR ships a consumer-facing skill document (`skills/stripe-interface/SKILL.md`) alongside packaging updates that include `docs` and `skills` directories in the npm bundle and register the skills directory via `antelopeJs.skills`. The SKILL.md content was verified against `src/index.ts` and all function signatures, parameter descriptions, and behavioral gotchas are accurate.

- **`skills/stripe-interface/SKILL.md`**: New skill file covering imports, usage examples for all six exported functions, and a detailed gotchas section — all verified against the actual implementation.
- **`package.json`**: Adds `docs` and `skills` to the `files` array (both directories exist) and registers `"./skills"` under `antelopeJs.skills` for automatic syncing by the AntelopeJS Claude Code plugin.

<h3>Confidence Score: 5/5</h3>

Safe to merge — this is a documentation and packaging-only change with no runtime code modifications.

All function signatures, parameter types, behavioral descriptions, and gotchas in SKILL.md were verified against src/index.ts and match the implementation exactly. The WatchAllPayments example correctly addresses the prior review feedback by splitting into two clearly labelled, mutually exclusive alternatives. Both docs/ and skills/ directories exist in the repo, so adding them to the npm files array is sound. No logic changes were made.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| skills/stripe-interface/SKILL.md | New consumer skill guide; all imports, function signatures, and behavioral claims verified against src/index.ts; WatchAllPayments example correctly shows two mutually exclusive alternatives addressing prior review feedback. |
| package.json | Adds existing docs/ and new skills/ directories to npm files array and registers the skills path under antelopeJs config; both directories confirmed to exist in the repo. |

</details>

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Consumer
    participant Interface as @antelopejs/interface-stripe
    participant Provider as Stripe Provider Module
    participant Stripe as Stripe API

    Provider->>Interface: SetClient(stripeInstance)
    Note over Interface: internal.client resolves

    Consumer->>Interface: InitializePayment(id, params)
    Interface->>Stripe: paymentIntents.create(params)
    Stripe-->>Interface: PaymentIntent
    Interface-->>Consumer: PaymentIntent

    Consumer->>Interface: WaitForPayment(intentId)
    Interface->>Stripe: paymentIntents.retrieve(intentId)
    Stripe-->>Interface: PaymentIntent (status check)

    Provider->>Interface: intentChanges.emit(intent, context)
    Note over Interface: Dispatches to WatchAllPayments,<br/>WatchPayment, WaitForPayment listeners

    Interface-->>Consumer: "resolved PaymentIntent (succeeded)<br/>or throws cancellation_reason (canceled)"
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Consumer
    participant Interface as @antelopejs/interface-stripe
    participant Provider as Stripe Provider Module
    participant Stripe as Stripe API

    Provider->>Interface: SetClient(stripeInstance)
    Note over Interface: internal.client resolves

    Consumer->>Interface: InitializePayment(id, params)
    Interface->>Stripe: paymentIntents.create(params)
    Stripe-->>Interface: PaymentIntent
    Interface-->>Consumer: PaymentIntent

    Consumer->>Interface: WaitForPayment(intentId)
    Interface->>Stripe: paymentIntents.retrieve(intentId)
    Stripe-->>Interface: PaymentIntent (status check)

    Provider->>Interface: intentChanges.emit(intent, context)
    Note over Interface: Dispatches to WatchAllPayments,<br/>WatchPayment, WaitForPayment listeners

    Interface-->>Consumer: "resolved PaymentIntent (succeeded)<br/>or throws cancellation_reason (canceled)"
```

</a>

<sub>Reviews (6): Last reviewed commit: ["docs(skills): use fictional domain value..."](https://github.com/antelopejs/interface-stripe/commit/3ea4d1c1fb6e127aee760176189988a15e8d5aac) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45477206)</sub>

<!-- /greptile_comment -->